### PR TITLE
feat(api): add JSON health response

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,14 @@ The default `pii_en_small` model uses the label `name` and a threshold of `0.9`.
 
 ### `GET /status`
 
-Returns `healthy` when the service is running and the model is loaded.
+Returns a standard JSON health response when the service is running and the model is loaded.
+
+```json
+{
+  "status": "UP",
+  "applicationVersion": "1.3.0"
+}
+```
 
 ## License
 

--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@
 import importlib
 import os
 
-from flask import Flask, request
+from flask import Flask, jsonify, request
 from waitress import serve
 
 __version__ = "1.3.0"
@@ -32,7 +32,7 @@ print("Model loaded and ready to serve requests")
 
 @app.route("/status", methods=["GET"])
 def status():
-    return "healthy"
+    return jsonify(status="UP", applicationVersion=__version__)
 
 
 @app.route("/find", methods=["POST"])

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -6,7 +6,7 @@ Ph-Eye provides two endpoints: `GET /status` and `POST /find`.
 
 **Endpoint:** `GET /status`
 
-Returns `healthy` when the service is running and the model is loaded.
+Returns a standard JSON health response when the service is running and the model is loaded.
 
 **Example request:**
 
@@ -16,8 +16,11 @@ curl http://localhost:5000/status
 
 **Example response:**
 
-```
-healthy
+```json
+{
+  "status": "UP",
+  "applicationVersion": "1.3.0"
+}
 ```
 
 ## Find entities

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -56,10 +56,11 @@ def reset_mock():
 
 # --- /status ---
 
-def test_status_returns_healthy(client):
+def test_status_returns_standard_health_response(client):
     response = client.get("/status")
     assert response.status_code == 200
-    assert response.data == b"healthy"
+    assert response.is_json
+    assert response.get_json() == {"status": "UP", "applicationVersion": "1.3.0"}
 
 
 # --- /find ---


### PR DESCRIPTION
## Summary
Updates the existing `/status` endpoint to return the standard JSON health contract with `status: "UP"` and the application `__version__`, while preserving the endpoint path for compatibility. Adds API test coverage and updates the README and usage documentation.

Closes #9