### PR TITLE
fix: rename health endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Pinned the Hugging Face revision for each `ph-eye-pii-en-*` model so Docker builds are reproducible and air-gapped at runtime. A new `MODEL_REVISION` environment variable can override it.
 - Deprecated the `pii_base` model module. It still loads `ph-eye-pii-base` when explicitly selected with `PHEYE_MODEL=pii_base`, but it is no longer the default and may be removed in a future release. To keep the previous behavior temporarily, pin `PHEYE_MODEL=pii_base`.
 - The `latest` Docker tag (and `latest-gpu`) now points at the default `pii_en_small` model, so `docker pull philterd/ph-eye` gets the new default English model.
+- Renamed the health check endpoint from `/status` to `/health`.
 
 ## 1.2.5 (2026-05-26)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ docker compose -f docker-compose.gpu.yaml up   # GPU
 Check that the service is up:
 
 ```bash
-curl http://localhost:5000/status
+curl http://localhost:5000/health
 ```
 
 ## API
@@ -103,7 +103,7 @@ The default `pii_en_small` model uses the label `name` and a threshold of `0.9`.
 ]
 ```
 
-### `GET /status`
+### `GET /health`
 
 Returns a standard JSON health response when the service is running and the model is loaded.
 

--- a/app.py
+++ b/app.py
@@ -30,8 +30,8 @@ model = model_module.load()
 print("Model loaded and ready to serve requests")
 
 
-@app.route("/status", methods=["GET"])
-def status():
+@app.route("/health", methods=["GET"])
+def health():
     return jsonify(status="UP", applicationVersion=__version__)
 
 

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -1,17 +1,17 @@
 # API Usage
 
-Ph-Eye provides two endpoints: `GET /status` and `POST /find`.
+Ph-Eye provides two endpoints: `GET /health` and `POST /find`.
 
 ## Health check
 
-**Endpoint:** `GET /status`
+**Endpoint:** `GET /health`
 
 Returns a standard JSON health response when the service is running and the model is loaded.
 
 **Example request:**
 
 ```bash
-curl http://localhost:5000/status
+curl http://localhost:5000/health
 ```
 
 **Example response:**

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -54,13 +54,18 @@ def reset_mock():
     yield
 
 
-# --- /status ---
+# --- /health ---
 
-def test_status_returns_standard_health_response(client):
-    response = client.get("/status")
+def test_health_returns_standard_health_response(client):
+    response = client.get("/health")
     assert response.status_code == 200
     assert response.is_json
     assert response.get_json() == {"status": "UP", "applicationVersion": "1.3.0"}
+
+
+def test_status_is_not_registered(client):
+    response = client.get("/status")
+    assert response.status_code == 404
 
 
 # --- /find ---


### PR DESCRIPTION
## Summary
- rename the health endpoint from /status to /health`n- add coverage that /status is no longer registered`n- update README, usage docs, and changelog

Closes #11

## Testing
- python -m pytest tests/test_app.py`n- git diff --check`n
Note: installing the full requirements locally currently hits a dependency conflict between gliner==0.2.26 and 	ransformers==5.5.0, so I installed only the missing waitress==3.0.2 package needed to run this focused test file.